### PR TITLE
Fix single array preventing .boundingBox() to work

### DIFF
--- a/globalFunctions/solveMILP.m
+++ b/globalFunctions/solveMILP.m
@@ -40,11 +40,11 @@ switch optSolver.milpSolver
         if ~isempty([A b]) && isempty([Aeq beq])
             model.sense = '<';
             model.A = sparse(A);
-            model.rhs = b;
+            model.rhs = double(full(b));
         elseif isempty([A b]) && ~isempty([Aeq beq])
             model.sense = '=';
             model.A = sparse(Aeq);
-            model.rhs = beq;
+            model.rhs = double(full(beq));
         elseif isempty([A b]) && isempty([Aeq beq])
             model.sense = '=';
             model.A = sparse(zeros(0,length(lb)));


### PR DESCRIPTION
The issue appears to be with the model.rhs in gurobi requires a dense double vector.
I've added a double and full to the assignment of model.rhs alongside the sparse() assignment for model.A in solveMIPL.

Fix associated w/ issue 51 in Applied-Systems-Lab/zonoLAB from @JChenUTD 